### PR TITLE
Add `.expectUpgrade` utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ provide compatibility with native supertest requests such as `post`,
   - [.close([code[, reason]]](#closecode-reason)
   - [.expectClosed([expectedCode[, expectedReason]])](#expectclosedexpectedcode-expectedreason)
   - [.expectConnectionError([expectedStatusCode])](#expectconnectionerrorexpectedstatuscode)
+  - [.expectUpgrade(fn)](#expectupgradefn)
   - [.wait(milliseconds)](#waitmilliseconds)
   - [.exec(fn)](#execfn)
 
@@ -277,6 +278,17 @@ request(server).ws('...')
 
 request(server).ws('...')
   .expectConnectionError(404); // specific error
+```
+
+### `.expectUpgrade(fn)`
+
+Run a check against the Upgrade response. If the predicate returns true
+the check passes, or if false, the check fails. Useful for making
+arbitrary assertions about parts of the Upgrade response, such as headers.
+
+```javascript
+request(server).ws('...)
+  .expect((req) => req.headers['set-cookie'] === 'foo=bar');
 ```
 
 ### `.wait(milliseconds)`

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'superwstest' {
-  import { Server, ClientRequestArgs } from 'http';
+  import { Server, ClientRequestArgs, IncomingMessage } from 'http';
   import WebSocket from 'ws';
   import { SuperTest, Test } from 'supertest';
 
@@ -35,6 +35,8 @@ declare module 'superwstest' {
       expectedCode?: number | null,
       expectedReason?: string | null,
     ): this;
+
+    expectUpgrade(test: (request: IncomingMessage) => boolean): this;
 
     expectConnectionError(expectedCode?: number | null): Promise<WebSocket>;
   }

--- a/src/superwstest.test.js
+++ b/src/superwstest.test.js
@@ -458,6 +458,13 @@ describe('superwstest', () => {
     expect(delayComplete).toEqual(true);
   });
 
+  it('checks the upgrade response', async () => {
+    await request(server)
+      .ws('/path/ws')
+      .expectUpgrade((req) => req.statusCode === 101)
+      .close();
+  });
+
   it('closes if exec throws', async () => {
     let ws;
     try {
@@ -503,5 +510,20 @@ describe('superwstest', () => {
 
     expect(capturedError).not.toEqual(null);
     expect(capturedError.message).toContain('WebSocket is not open');
+  });
+
+  it('produces errors if the upgrade check fails', async () => {
+    let capturedError = null;
+
+    try {
+      await request(server)
+        .ws('/path/ws')
+        .expectUpgrade((req) => req.statusCode === 200);
+    } catch (e) {
+      capturedError = e;
+    }
+
+    expect(capturedError).not.toEqual(null);
+    expect(capturedError.message).toContain('Upgrade assertion returned false');
   });
 });


### PR DESCRIPTION
This change adds `.expectUpgrade` to the chain, which allows consumers
to make arbitrary assertions about the Upgrade response. This is
particularly useful when checking cookies that have been set on the
Upgrade response, for example.