### PR TITLE
Export typescript types from index.d.ts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+index.d.ts

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-index.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'superwstest' {
-  import { Server, ClientRequestArgs, IncomingMessage } from 'http';
-  import WebSocket from 'ws';
-  import { SuperTest, Test } from 'supertest';
+  import type { Server, ClientRequestArgs, IncomingMessage } from 'http';
+  import type WebSocket from 'ws';
+  import type { SuperTest, Test } from 'supertest';
 
   export type JsonObject = { [member: string]: JsonValue };
   export interface JsonArray extends Array<JsonValue> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,10 @@ declare module 'superwstest' {
   import type WebSocket from 'ws';
   import type { SuperTest, Test } from 'supertest';
 
-  export type JsonObject = { [member: string]: JsonValue };
-  export interface JsonArray extends Array<JsonValue> {}
-  export type JsonValue = JsonObject | JsonArray | string | number | boolean | null;
+  type JsonObject = { [member: string]: JsonValue };
+  interface JsonArray extends Array<JsonValue> {}
+  type JsonValue = JsonObject | JsonArray | string | number | boolean | null;
+
   export interface ReceivedMessage {
     data: Buffer;
     isBinary: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,15 +3,15 @@ declare module 'superwstest' {
   import WebSocket from 'ws';
   import { SuperTest, Test } from 'supertest';
 
-  type JsonObject = { [member: string]: JsonValue };
-  interface JsonArray extends Array<JsonValue> {}
-  type JsonValue = JsonObject | JsonArray | string | number | boolean | null;
-  interface ReceivedMessage {
+  export type JsonObject = { [member: string]: JsonValue };
+  export interface JsonArray extends Array<JsonValue> {}
+  export type JsonValue = JsonObject | JsonArray | string | number | boolean | null;
+  export interface ReceivedMessage {
     data: Buffer;
     isBinary: boolean;
   }
 
-  interface WSChain extends Promise<WebSocket> {
+  export interface WSChain extends Promise<WebSocket> {
     send(message: any, options?: { mask?: boolean; binary?: boolean; compress?: boolean; fin?: boolean }): this;
     sendText(message: any): this;
     sendJson(message: JsonValue): this;
@@ -45,12 +45,12 @@ declare module 'superwstest' {
     expectConnectionError(expectedCode?: number | null): Promise<WebSocket>;
   }
 
-  interface SuperWSTest extends SuperTest<Test> {
+  export interface SuperWSTest extends SuperTest<Test> {
     ws(path: string, options?: WebSocket.ClientOptions | ClientRequestArgs): WSChain;
     ws(path: string, protocols?: string | string[], options?: WebSocket.ClientOptions | ClientRequestArgs): WSChain;
   }
 
-  interface RequestOptions {
+  export interface RequestOptions {
     shutdownDelay?: number;
   }
 
@@ -63,5 +63,5 @@ declare module 'superwstest' {
     function closeAll(): void;
   }
 
-  export = request;
+  export default request;
 }


### PR DESCRIPTION
Right now individual types are not being exported the `index.d.ts` file so they can't be reused outside of this module. For example in our use case we would need to access the `WSChain` for a utility function which wraps `superwstest` which fails with the current types:

```ts
import wsRequest, { WSChain } from 'superwstest'; // WSChain is not exported and can't be reused

export async function createApiWebsocketConnection(
  app: INestApplication,
  route: string,
  authToken?: string,
): Promise<{ connection: WSChain }> {
  const headers = {};

  if (authToken) {
    headers['Authorization'] = `Bearer ${authToken}`;
  }

  const randomPort = await getPort();
  await app.listen(randomPort);

  const connection = wsRequest(app.getHttpServer())
    .ws(`${route}/subscriptions`, ['graphql-ws'])
    .sendJson({
      payload: headers,
      type: GraphQlSubscriptionType.CONNECTION_INIT,
    })
    .expectJson({
      type: GraphQlSubscriptionType.CONNECTION_ACKNOWLEDGED,
    });

  return { connection };
}
```

This pr attempts to fix this by exporting the types in addition to the default export. It works for us in combination with typescript `4.4.2`. It also adds a `.eslintignore` file which ignores the `index.d.ts` file as it was wrongly complaining about type declarations  with the following error: `Parsing error: Imports within a 'declare module' body must always be 'import type' or 'import typeof'.`