### PR TITLE
Update to support ws library

### DIFF
--- a/build/superwstest.js
+++ b/build/superwstest.js
@@ -382,7 +382,10 @@ function wsRequest(config, url, protocols, options) {
 
 function performShutdown(sockets, shutdownDelay) {
   if (shutdownDelay <= 0) {
-    [...sockets].forEach((s) => s.end());
+    [...sockets].forEach((s) => {
+      if(s.end) s.end(); 
+      else if (s.close) s.close();
+    });
     return;
   }
 
@@ -394,7 +397,8 @@ function performShutdown(sockets, shutdownDelay) {
       await new Promise((r) => setTimeout(r, 20));
     }
     if (sockets.has(s)) {
-      s.end();
+      if(s.end) s.end(); 
+      else if (s.close) s.close();
     }
   });
 }

--- a/src/superwstest.mjs
+++ b/src/superwstest.mjs
@@ -335,7 +335,10 @@ function wsRequest(config, url, protocols, options) {
 
 function performShutdown(sockets, shutdownDelay) {
   if (shutdownDelay <= 0) {
-    [...sockets].forEach((s) => s.end());
+    [...sockets].forEach((s) => {
+      if(s.end) s.end() 
+      else if (s.close) s.close()
+    });
     return;
   }
 
@@ -347,7 +350,8 @@ function performShutdown(sockets, shutdownDelay) {
       await new Promise((r) => setTimeout(r, 20));
     }
     if (sockets.has(s)) {
-      s.end();
+      if(s.end) s.end() 
+      else if (s.close) s.close()
     }
   });
 }


### PR DESCRIPTION
Hi @artem7902 - I saw you forked the repository to make it compatible with [WebSocketServer](https://github.com/websockets/ws/blob/master/doc/ws.md#class-websocketserver) servers. I think that's a reasonable thing for the core project to be compatible with, so I've made this PR to discuss your changes.

Your changes make the library mostly compatible, but it's still possible for somebody to make a https WebSocketServer, and because of [this line](https://github.com/davidje13/superwstest/blob/main/src/superwstest.mjs#L405), that won't be detected correctly (the library will communicate as http).

I wonder if instead it might be possible to access the underlying raw server [here](https://github.com/davidje13/superwstest/blob/main/src/superwstest.mjs#L425), though I see that there is no official API for this in `ws` (it could be done with `server._server` but that's not very future-proof). I raised a request on the `ws` project: https://github.com/websockets/ws/issues/2068 — let's see what they think.

Finally, it would of course be nice to get some basic testing for this compatibility, but I can pick that up if you're not interested.