### PR TITLE
feat: expect eventually

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ declare module 'superwstest' {
   }
 
   export interface ExpectMessageOptions {
+    eventually?: boolean | undefined;
     timeout?: number | undefined;
   }
 

--- a/src/superwstest.mjs
+++ b/src/superwstest.mjs
@@ -116,16 +116,33 @@ const wsMethods = {
         );
       }),
     ]).then(conversion);
-    if (check === undefined) {
-      return;
-    }
-    if (typeof check === 'function') {
-      const result = check(received);
-      if (result === false) {
+
+    try {
+      if (check === undefined) {
+        return;
+      }
+      if (typeof check === 'function') {
+        const result = check(received);
+        if (result === false) {
+          throw new Error(`Expected message ${stringify(check)}, got ${stringify(received)}`);
+        }
+      } else if (!util.isDeepStrictEqual(received, check)) {
         throw new Error(`Expected message ${stringify(check)}, got ${stringify(received)}`);
       }
-    } else if (!util.isDeepStrictEqual(received, check)) {
-      throw new Error(`Expected message ${stringify(check)}, got ${stringify(received)}`);
+    } catch (e) {
+      opts.startTime ??= Date.now();
+
+      if (opts.eventually) {
+        opts.timeout ??= 1000;
+
+        if (Date.now() - opts.startTime > opts.timeout) {
+          throw e;
+        }
+
+        return wsMethods.expectMessage(ws, conversion, check, opts);
+      }
+
+      throw e;
     }
   },
   expectText: (ws, expected, options) => {


### PR DESCRIPTION
sometimes there is a lot of noise over the channel, and we send a lot of various messages that are prone to change, I just need to check that we _eventually_ get a message back from the WS, ignoring the messages before if they don't match.

In this case, a timeout should always be set. 
We basically recursively do `ws.messages.pop` until something matches or it times out.